### PR TITLE
Add call to action to talk with participants

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@ weight: 1
 						<div style="width:100%; text-align:left;" ><iframe  src="//eventbrite.co.uk/tickets-external?eid=16233380478&ref=etckt" frameborder="0" style="min-height:375px;" width="100%" vspace="0" hspace="0" marginheight="5" marginwidth="5" scrolling="no" allowtransparency="true"></iframe></div>
 					</div>
 					<h3>
-						Meet other participants. Follow the <a href="https://twitter.com/search?q=%23golanguk15" target="_blank">#golanguk15 tweets</a> or get on the <a href="https://slackline.io/shared_channels/golang-uk-conf" target="_blank">Golang UK channel in Slackline</a>
+						Meet other participants. Follow the <a href="https://twitter.com/search?q=%23gouk15" target="_blank">#gouk15 tweets</a> or get on the <a href="https://slackline.io/shared_channels/golang-uk-conf" target="_blank">Golang UK channel in Slackline</a>
 					</h3>
 				</div>
     		</div>

--- a/index.html
+++ b/index.html
@@ -19,6 +19,9 @@ weight: 1
 					<div class="subscribe">
 						<div style="width:100%; text-align:left;" ><iframe  src="//eventbrite.co.uk/tickets-external?eid=16233380478&ref=etckt" frameborder="0" style="min-height:375px;" width="100%" vspace="0" hspace="0" marginheight="5" marginwidth="5" scrolling="no" allowtransparency="true"></iframe></div>
 					</div>
+					<h3>
+						Meet other participants. Follow the <a href="https://twitter.com/search?q=%23golanguk15" target="_blank">#golanguk15 tweets</a> or get on the <a href="https://slackline.io/shared_channels/golang-uk-conf" target="_blank">Golang UK channel in Slackline</a>
+					</h3>
 				</div>
     		</div>
     	</div>


### PR DESCRIPTION
Included a call to action in the home page to talk with other
participants via the twitter hashtag or the Slackline channel.