### PR TITLE
Updating text on the ticket page to not display empty eventbrite.

### DIFF
--- a/tickets/index.html
+++ b/tickets/index.html
@@ -8,11 +8,12 @@ group: "navigation"
 <div class="page-title tickets">
     <div class="wrapper">
         <h1>Tickets</h1>
-        <h2>Buy your conference tickets</h2>
+<!--         <h2>Buy your conference tickets</h2> -->
     </div>
 </div>
 <div class="row">
     <div class="wrapper">
-        <iframe src="//eventbrite.co.uk/tickets-external?eid=21135268156&ref=etckt" frameborder="0" height="900" width="100%" vspace="0" hspace="0" marginheight="5" marginwidth="5" scrolling="auto" allowtransparency="true"></iframe>
+        <p>Tickets are currently not available yet. Please follow <a href="https://twitter.com/golangukconf">@golangukconf on Twitter</a> for news of when ticket sales opens.</p>
+<!--         <iframe src="//eventbrite.co.uk/tickets-external?eid=21135268156&ref=etckt" frameborder="0" height="900" width="100%" vspace="0" hspace="0" marginheight="5" marginwidth="5" scrolling="auto" allowtransparency="true"></iframe> -->
     </div>
 </div>


### PR DESCRIPTION
If ticket page is visited directly, there'll no longer be an empty Eventbrite frame.